### PR TITLE
added port to migrations-db

### DIFF
--- a/src/migrations-db.php
+++ b/src/migrations-db.php
@@ -28,6 +28,7 @@ return [
     'user' => $facts->getDatabaseUserName(),
     'password' => $facts->getDatabasePassword(),
     'host' => $facts->getDatabaseHost(),
+    'port' => $facts->getDatabasePort(),
     'driver' => $facts->getDatabaseDriver(),
     'charset' => 'utf8',
     'driverOptions' => [


### PR DESCRIPTION
This is needed to run migrations with a non standard mysql port.
This is the case with a lot of hosters, in my case Profihost.
I consider this a blocker for using OXID.

Related PR: https://github.com/OXID-eSales/oxideshop-facts/pull/1

Once the above PR is merged and released ill adjust composer.json
