### PR TITLE
6886: exclude non-essential files from dist package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+/tests/ export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore


### PR DESCRIPTION
* [Bugtrack #6886](https://bugs.oxid-esales.com/view.php?id=6886)
* https://github.com/OXID-eSales/oxideshop_ce/pull/673