### PR TITLE
Added the possibility to use doctrine migration flags

### DIFF
--- a/bin/migrate.php
+++ b/bin/migrate.php
@@ -35,5 +35,34 @@ $migrations = $migrationsBuilder->build();
 
 $command = $argv[1] ?? null;
 $edition = $argv[2] ?? null;
+$flags = [];
 
-exit($migrations->execute($command, $edition));
+if (isset($argv[3])) {
+
+    // Do not alter $argv itself
+    $copyOfArgv = $argv;
+
+    unset(
+        $copyOfArgv[0],
+        $copyOfArgv[1],
+        $copyOfArgv[2]
+    );
+
+    foreach ($copyOfArgv as $flag) {
+
+        /*
+         * Determines if a param has also a value
+         * if case  : --write-sql=/var/www/html/source/migration/project_data/
+         * else case: --dry-run
+         */
+        $keyValuePair = preg_split('/=/', $flag);
+
+        if (count($keyValuePair) === 2) {
+            $flags[$keyValuePair[0]] = $keyValuePair[1];
+        } else {
+            $flags[$flag] = null;
+        }
+    }
+}
+
+exit($migrations->execute($command, $edition, $flags));


### PR DESCRIPTION
In short: This PR offers the option to use the Doctrine migrations:migrate flags with our Doctrine wrapper.

Currently the migration wrapper doesn't pipe Doctrine commands to the Doctrine migration library. 
This PR adds the option to to pipe all flags behind `<doctrine command> <edition>` to the Doctrine Migration.

Examples

`vendor/bin/oe-eshop-db_migrate migrations:migrate PR --dry-run`
Without this PR the flag is not respected. The PR considers this flag and so the migration will not be executed. You will only see which queries would be fired, but nothing will happen on the database.

`vendor/bin/oe-eshop-db_migrate migrations:migrate PR --write-sql=/var/www/html/source/migration/project_data/`
This flags value will be considered and piped to the Doctrine wrapper.

Please note:
- This PR works only with the flags from the `migration` command. Other Doctrine Migration commands like `status` or `version` will probably not work.
- When you want to use the flags you must use the [suite_type](https://github.com/OXID-eSales/oxideshop-doctrine-migration-wrapper/tree/b-3.x#suite-types-generate-migration-for-a-single-suite):
Example: `vendor/bin/oe-eshop-db_migrate migrations:migrate <suite> <flags>`