### PR TITLE
Remove useless dependency on composer/package-versions-deprecated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
   "require": {
     "php": "^7.4 || ^8.0",
     "doctrine/migrations": "^2.3.2",
-    "composer/package-versions-deprecated": "^1",
     "oxid-esales/oxideshop-facts": "^3.0.0",
     "symfony/console": "^5.0.4"
   },


### PR DESCRIPTION
This package was added as a dependency to keep support for PHP 7.1 while supporting composer 2, to replace ocramius/package-versions

However, this is not necessary anymore:
- old PHP versions have been dropped
- doctrine/migrations stopped using ocramius/package-versions so there is no need to force replacing it